### PR TITLE
Fix slug unique validation with locale

### DIFF
--- a/src/Http/Resources/MenuResource.php
+++ b/src/Http/Resources/MenuResource.php
@@ -58,7 +58,7 @@ class MenuResource extends Resource
 
             Text::make(__('Slug'), 'slug')
                 ->sortable()
-                ->rules('required', 'max:255', 'unique:menus,slug,NULL,NULL,locale,' . $request->locale),
+                ->rules('required', 'max:255', Rule::unique('menus', 'slug')->where('locale', $request->get('locale'))),
 
             Select::make(__('Locale'), 'locale')
                 ->options(MenuBuilder::getLocales())


### PR DESCRIPTION
Hi, this validation rule was not working for me, the generated query would fail like this: 
```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'NULL' in 'where clause' (SQL: select count(*) as aggregate from `menus` where `slug` = /head and `NULL` <>  and `locale` = en)
```

This patch fixes that problem and now it works for me.