### PR TITLE
Fix missing parameter in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ public static function getName(): string {
  *
  * @return array
  **/
-public static function getOptions(): array {
+public static function getOptions($locale): array {
     // Example usecase
     // return Page::all()->pluck('name', 'id');
     return [];


### PR DESCRIPTION
The source class has a $locale parameter, which was missing from the docs, causing an error