### PR TITLE
order MenuItem children by 'order' column

### DIFF
--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -25,7 +25,7 @@ class MenuItem extends Model
 
     public function children()
     {
-        return $this->hasMany(self::class, 'parent_id')->with('children');
+        return $this->hasMany(self::class, 'parent_id')->with('children')->orderby('order');
     }
 
     public function itemsChildren($parentId)


### PR DESCRIPTION
Fixes an issue where $menu->formatForAPI() menuItem's children would not be ordered correctly