### PR TITLE
Prevent syntax error

### DIFF
--- a/src/MenuBuilder.php
+++ b/src/MenuBuilder.php
@@ -47,7 +47,7 @@ class MenuBuilder extends Tool
         $configuredLinkableModels = config('nova-menu.linkable_models', []);
         return array_merge(
             static::$defaultLinkableModels,
-            $configuredLinkableModels,
+            $configuredLinkableModels
         );
     }
 


### PR DESCRIPTION
The trailing comma triggers an error when trying to execute the migration. 