### PR TITLE
Accepting Parameters even in Display Value

### DIFF
--- a/src/Classes/MenuItemBase.php
+++ b/src/Classes/MenuItemBase.php
@@ -35,9 +35,10 @@ abstract class MenuItemBase
      * Get the subtitle value shown in CMS menu items list.
      *
      * @param string $value
+     * @param array $parameters The JSON parameters added to the item.
      * @return string
      **/
-    public static function getDisplayValue($value = null)
+    public static function getDisplayValue($value = null, array $parameters = null)
     {
         return $value;
     }

--- a/src/Classes/MenuItemText.php
+++ b/src/Classes/MenuItemText.php
@@ -19,7 +19,7 @@ abstract class MenuItemText extends MenuItemBase
         return 'text';
     }
 
-    public static function getDisplayValue($value = null)
+    public static function getDisplayValue($value = null, array $parameters = null)
     {
         return '';
     }

--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -58,7 +58,7 @@ class MenuItem extends Model
     public function getDisplayValueAttribute()
     {
         if (class_exists($this->class)) {
-            return $this->class::getDisplayValue($this->value);
+            return $this->class::getDisplayValue($this->value, $this->parameters);
         }
         return $this->value;
     }


### PR DESCRIPTION
Since you aready accept parameter for "TypeAttribute" and "CustomValueAttribute" is logical (and even usefull) to be able to accepts parameters even in display values.

this way you could easly manage big tables without over populated "select" type, enabling a sorta-conditional use of the menu.
for example this way you could define in parameters some filters (eg. "slug": "something", "category": "someother") and display proper data as you (already) get your value.

