### PR TITLE
Customizable MenuItem model.

### DIFF
--- a/config/nova-menu.php
+++ b/config/nova-menu.php
@@ -11,6 +11,16 @@ return [
 
     'resource' => OptimistDigital\MenuBuilder\Http\Resources\MenuResource::class,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Menu Item Model
+    |--------------------------------------------------------------------------
+    |
+    | Optionally override the original Menu Item model.
+    */
+
+    'menu_item_model' => OptimistDigital\MenuBuilder\Models\MenuItem::class,
+
 
     /*
     |--------------------------------------------------------------------------

--- a/src/MenuBuilder.php
+++ b/src/MenuBuilder.php
@@ -4,6 +4,7 @@ namespace OptimistDigital\MenuBuilder;
 
 use Laravel\Nova\Nova;
 use Laravel\Nova\Tool;
+use OptimistDigital\MenuBuilder\Models\MenuItem;
 
 class MenuBuilder extends Tool
 {
@@ -64,5 +65,10 @@ class MenuBuilder extends Tool
     public static function getMenuItemsTableName()
     {
         return config('nova-menu.menu_items_table_name', 'nova_menu_menu_items');
+    }
+
+    public static function getMenuItemsModel()
+    {
+        return config('nova-menu.menu_item_model', MenuItem::class);
     }
 }

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -41,7 +41,7 @@ class Menu extends Model
     public function rootMenuItems()
     {
         return $this
-            ->hasMany(MenuItem::class)
+            ->hasMany(MenuBuilder::getMenuItemsModel())
             ->where('parent_id', null)
             ->orderBy('parent_id')
             ->orderBy('order')


### PR DESCRIPTION
Added possibility to customize/extend the MenuItem model in the config file and wherever it was called directly.

In some situations we may want to add functionality to the MenuItem like relationships to another models. E.g: ```audits()```.

Or any other need, like an easier way to add observers, etc.

The MenuItem model is now in the config file, as the Menu resource, with the fallback to the original Model.