### PR TITLE
PHP 8: Deprecate required parameters after optional parameters

### DIFF
--- a/src/MenuItemTypes/BaseMenuItemType.php
+++ b/src/MenuItemTypes/BaseMenuItemType.php
@@ -37,7 +37,7 @@ abstract class BaseMenuItemType
      * @param $locale
      * @return string
      */
-    public static function getDisplayValue($value = null, array $data = null, $locale)
+    public static function getDisplayValue($locale, $value = null, array $data = null)
     {
         return $value;
     }
@@ -56,7 +56,7 @@ abstract class BaseMenuItemType
      * @param $locale
      * @return any
      */
-    public static function getValue($value = null, array $data = null, $locale)
+    public static function getValue($locale, $value = null, array $data = null)
     {
         return $value;
     }

--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -73,7 +73,7 @@ class MenuItem extends Model
     public function getCustomValueAttribute()
     {
         if (class_exists($this->class)) {
-            return $this->class::getValue($this->value, $this->data, $this->locale);
+            return $this->class::getValue($this->locale, $this->value, $this->data);
         }
         return $this->value;
     }

--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -57,7 +57,7 @@ class MenuItem extends Model
     public function getDisplayValueAttribute()
     {
         if (class_exists($this->class)) {
-            return $this->class::getDisplayValue($this->value, $this->data, $this->locale);
+            return $this->class::getDisplayValue($this->locale, $this->value, $this->data);
         }
         return $this->value;
     }


### PR DESCRIPTION
Required parameters have to be before optional parameter in function/method signature since PHP8 ([reference](https://php.watch/versions/8.0/deprecate-required-param-after-optional)).

Encountered this exception `Required parameter $locale follows optional parameter $value`

