### PR TITLE
Fix migrations for SQLite

### DIFF
--- a/database/migrations/2020_09_15_000000_rework_locale_handling.php
+++ b/database/migrations/2020_09_15_000000_rework_locale_handling.php
@@ -79,6 +79,8 @@ class ReworkLocaleHandling extends Migration
 
         Schema::table(MenuBuilder::getMenusTableName(), function ($table) {
             $table->dropUnique('nova_menu_menus_slug_locale_unique');
+        });
+        Schema::table(MenuBuilder::getMenusTableName(), function ($table) {
             $table->dropColumn('locale');
         });
         Schema::table(MenuBuilder::getMenusTableName(), function ($table) {

--- a/database/migrations/2020_09_15_000000_rework_locale_handling.php
+++ b/database/migrations/2020_09_15_000000_rework_locale_handling.php
@@ -79,7 +79,6 @@ class ReworkLocaleHandling extends Migration
 
         Schema::table(MenuBuilder::getMenusTableName(), function ($table) {
             $table->dropUnique('nova_menu_menus_slug_locale_unique');
-            $table->dropUnique('menus_locale_parent_id_locale_unique');
             $table->dropColumn('locale');
         });
         Schema::table(MenuBuilder::getMenusTableName(), function ($table) {

--- a/database/migrations/2020_09_15_000000_rework_locale_handling.php
+++ b/database/migrations/2020_09_15_000000_rework_locale_handling.php
@@ -81,6 +81,8 @@ class ReworkLocaleHandling extends Migration
             $table->dropUnique('nova_menu_menus_slug_locale_unique');
             $table->dropUnique('menus_locale_parent_id_locale_unique');
             $table->dropColumn('locale');
+        });
+        Schema::table(MenuBuilder::getMenusTableName(), function ($table) {
             $table->dropColumn('locale_parent_id');
         });
     }


### PR DESCRIPTION
This change contains three updates to the last migration, to fix some errors when using SQLite.

1. Prevent SQLite error for multiple dropColumn calls
Laravel will detect multiple calls to `dropColumn` and complain:

> "SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification.

The solution is to move these calls to separate `Schema::table()` blocks.

2. Remove duplicate unique index deletion
The index is dropped on line 87, and will throw an error when it reaches
line 94 containing the same statement.

3. Prevent error for unknown index
When using SQLite, this apparently throws an error saying

> SQLSTATE[HY000]: General error: 1 no such index: nova_menu_menus_slug_locale_unique

I think it somehow drops the column before dropping the index.
By separating this into multiple `Schema::table()` blocks, all
operations are executed in order.

------

Let me know if I can do anything to improve this! I think this helps the out-of-the-box applicability of this package when using SQLite.
Thanks!
