### PR TITLE
Use the configured MenuItem model when querying

### DIFF
--- a/src/Http/Controllers/MenuController.php
+++ b/src/Http/Controllers/MenuController.php
@@ -81,11 +81,13 @@ class MenuController extends Controller
     /**
      * Returns the menu item as JSON.
      *
-     * @param OptimistDigital\MenuBuilder\Models\MenuItem $menuItem
+     * @param $menuItemId
      * @return Illuminate\Http\Response
      **/
-    public function getMenuItem(MenuItem $menuItem)
+    public function getMenuItem($menuItemId)
     {
+        $menuItem = MenuBuilder::getMenuItemClass()::find($menuItemId);
+        
         return isset($menuItem)
             ? response()->json($menuItem, 200)
             : response()->json(['error' => 'item_not_found'], 400);


### PR DESCRIPTION
When querying the menu item model, the base model is used instead of the one defined in nova-menu.php. This is inconsistent with other actions such as updateMenuItem and deleteMenuItem.

This PR makes the behavior of the controller more consistent.