### PR TITLE
Add fillable attributes to Menu

### DIFF
--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -7,6 +7,8 @@ use OptimistDigital\MenuBuilder\MenuBuilder;
 
 class Menu extends Model
 {
+    protected $fillable = ['name', 'slug'];
+    
     public function __construct(array $attributes = [])
     {
         parent::__construct($attributes);


### PR DESCRIPTION
Adding fillable attributes to `src/Models/Menu.php` Model so we can use something like this:

```php
Menu::create([
    'name' => 'Test Menu',
    'slug' => 'test-menu',
]);
```

in tests for example. Without these fillable attributes we get an error like

```
Add [name] to fillable property to allow mass assignment on [OptimistDigital\MenuBuilder\Models\Menu].
```