### PR TITLE
Fix MenuItem children static binding

### DIFF
--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -31,7 +31,7 @@ class MenuItem extends Model
 
     public function children()
     {
-        return $this->hasMany(self::class, 'parent_id')->with('children')->orderBy('order');
+        return $this->hasMany(static::class, 'parent_id')->with('children')->orderBy('order');
     }
 
     public function itemsChildren($parentId)


### PR DESCRIPTION
Hi, because of ```self::class``` in ```children``` method class that extends ```MenuItem``` got wrong static binding in it's children and they call methods like ```getCustomDataAttribute``` or ```getCustomValueAttribute``` from original package class instead of extending one. 
Changing ```self::class``` to ```static::class``` fixed that problem me. I could redeclare ```children``` method, but this fix is more convenient imo 