### PR TITLE
Fix modal closing via escape.

### DIFF
--- a/resources/js/components/modals/UpdateMenuItemModal.vue
+++ b/resources/js/components/modals/UpdateMenuItemModal.vue
@@ -1,5 +1,9 @@
 <template>
-  <Modal :show="showModal" class="bg-white dark:bg-gray-800 rounded-lg shadow-lg" align="flex justify-end">
+  <Modal
+    :show="showModal"
+    class="bg-white dark:bg-gray-800 rounded-lg shadow-lg" align="flex justify-end"
+    @close-via-escape="$emit('close-modal')"
+  >
     <ModalHeader class="flex flex-wrap justify-between">
       {{ __(update ? 'novaMenuBuilder.updateModalTitle' : 'novaMenuBuilder.createModalTitle') }}
 


### PR DESCRIPTION
Fixed on/for:

laravel/nova: 5.7.5
outl1ne/nova-menu-builder: dev-main

Should probably be backported to previous versions too.

Didn't find how to add a "close" button with the correct "close"-action event.
