### PR TITLE
Fix 2 depreciation warnings for PHP 8.2 and symfony/http-foundation 7.4

### DIFF
--- a/src/Http/Controllers/MenuController.php
+++ b/src/Http/Controllers/MenuController.php
@@ -81,7 +81,7 @@ class MenuController extends Controller
      **/
     public function getMenuItems(Request $request, $menuId)
     {
-        $locale = $request->get('locale');
+        $locale = $request->input('locale');
         $menu = MenuBuilder::getMenuClass()::find($menuId);
 
         if (empty($menu)) return response()->json(['menu' => 'menu_not_found'], 400);
@@ -107,7 +107,7 @@ class MenuController extends Controller
      **/
     public function saveMenuItems(Request $request, $menuId)
     {
-        $items = $request->get('menuItems');
+        $items = $request->input('menuItems');
 
         $i = 1;
         foreach ($items as $item) {
@@ -202,7 +202,7 @@ class MenuController extends Controller
     {
         $menu = MenuBuilder::getMenuClass()::find($menuId);
         if ($menu === null) return response()->json(['error' => 'menu_not_found'], 404);
-        $locale = $request->get('locale');
+        $locale = $request->input('locale');
         if ($locale === null) return response()->json(['error' => 'locale_required'], 400);
 
         $menuItemTypes = [];

--- a/src/Http/Requests/MenuItemFormRequest.php
+++ b/src/Http/Requests/MenuItemFormRequest.php
@@ -33,7 +33,7 @@ class MenuItemFormRequest extends FormRequest
             ];
         }
 
-        $menuItemClass = $this->get('class');
+        $menuItemClass = $this->input('class');
         $menuItemId = $this->route('menuItem');
         $menuItem = MenuBuilder::getMenuItemClass()::find($menuItemId);
 

--- a/src/Nova/Fields/MenuBuilderField.php
+++ b/src/Nova/Fields/MenuBuilderField.php
@@ -9,7 +9,7 @@ class MenuBuilderField extends Field
 {
     public $component = 'menu-builder-field';
 
-    public function __construct($name, $attribute = null, callable $resolveCallback = null)
+    public function __construct($name, $attribute = null, ?callable $resolveCallback = null)
     {
         parent::__construct($name, $attribute, $resolveCallback);
 


### PR DESCRIPTION
Since Symfony 7.4, the get method is depricated as it can be seen here:
https://github.com/symfony/http-foundation/blob/977a554a34cf8edc95ca351fbecb1bb1ad05cc94/Request.php#L742

This cascades to Laravel's Illuminate\Http\Request and further extends to FormRequest, as it can be seen here:
https://github.com/laravel/framework/blob/93686c3b428bdc0d3a1ec7c2d7024869252b3e28/src/Illuminate/Http/Request.php#L427-L440

Also resolved this depreciation warning for PHP 8.2: https://github.com/outl1ne/nova-menu-builder/issues/225